### PR TITLE
Statische variabelen naar de preprocessor

### DIFF
--- a/breadboard/Breadboard_Input_Tests/Breadboard_Input_Tests.ino
+++ b/breadboard/Breadboard_Input_Tests/Breadboard_Input_Tests.ino
@@ -11,13 +11,13 @@
 */
 
 // Buttons -- Input
-int buttonLeft = 2;
-int buttonMiddle = 7;
-int buttonRight = 8;
+#define buttonLeft 2
+#define buttonMiddle 7
+#define buttonRight 8
 
 // Sliders -- Input
-int sliderLeft = 1;
-int sliderRight = 0;
+#define sliderLeft 1
+#define sliderRight 0
 
 // initial status values
 int buttonLeftStatus = -1;

--- a/breadboard/Breadboard_Output_Tests/Breadboard_Output_Tests.ino
+++ b/breadboard/Breadboard_Output_Tests/Breadboard_Output_Tests.ino
@@ -13,17 +13,17 @@ int tempo = 300;
 
 
 // Leds -- Output
-int ledLeftRed = 3;
-int ledLeftGreen = 5;
-int ledLeftBlue = 6;
+#define ledLeftRed 3
+#define ledLeftGreen 5
+#define ledLeftBlue 6
 
 // Leds -- Output
-int ledRightRed = 9;
-int ledRightGreen = 10;
-int ledRightBlue = 11;
+#define ledRightRed 9
+#define ledRightGreen 10
+#define ledRightBlue 11
 
 // Buzzer -- Output
-int buzzerPin = 4;
+#define buzzerPin 4
 
 void setup() {
   // -- Output


### PR DESCRIPTION
De variabelen die niet tijdens het uitvoeren van de code veranderen
vervangen door #define - dan doet de preprocessor het werk en scheelt
het geheugen op de Arduino.